### PR TITLE
refactor: improve VisualEditor architecture with separation of concerns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -159,7 +159,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
       "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.27.1",
         "js-tokens": "^4.0.0",
@@ -173,7 +173,7 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.5.tgz",
       "integrity": "sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -182,7 +182,7 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -212,7 +212,7 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.5.tgz",
       "integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@babel/parser": "^7.28.5",
         "@babel/types": "^7.28.5",
@@ -228,7 +228,7 @@
       "version": "7.27.2",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
       "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@babel/compat-data": "^7.27.2",
         "@babel/helper-validator-option": "^7.27.1",
@@ -244,7 +244,7 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
       "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -253,7 +253,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
       "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@babel/traverse": "^7.27.1",
         "@babel/types": "^7.27.1"
@@ -266,7 +266,7 @@
       "version": "7.28.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
       "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.27.1",
         "@babel/helper-validator-identifier": "^7.27.1",
@@ -283,7 +283,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -292,7 +292,7 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -301,7 +301,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
       "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -310,7 +310,7 @@
       "version": "7.28.4",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
       "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@babel/template": "^7.27.2",
         "@babel/types": "^7.28.4"
@@ -323,7 +323,7 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
       "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@babel/types": "^7.28.5"
       },
@@ -347,7 +347,7 @@
       "version": "7.27.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
       "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/parser": "^7.27.2",
@@ -361,7 +361,7 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
       "integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -379,7 +379,7 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
       "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
         "@babel/helper-validator-identifier": "^7.28.5"
@@ -1674,7 +1674,7 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -1684,7 +1684,7 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -1694,7 +1694,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1703,13 +1703,13 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -2024,7 +2024,7 @@
       "version": "6.19.0",
       "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.19.0.tgz",
       "integrity": "sha512-zwCayme+NzI/WfrvFEtkFhhOaZb/hI+X8TTjzjJ252VbPxAl2hWHK5NMczmnG9sXck2lsXrxIZuK524E25UNmg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "c12": "3.1.0",
@@ -2037,14 +2037,14 @@
       "version": "6.19.0",
       "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.19.0.tgz",
       "integrity": "sha512-8hAdGG7JmxrzFcTzXZajlQCidX0XNkMJkpqtfbLV54wC6LSSX6Vni25W/G+nAANwLnZ2TmwkfIuWetA7jJxJFA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
       "version": "6.19.0",
       "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.19.0.tgz",
       "integrity": "sha512-pMRJ+1S6NVdXoB8QJAPIGpKZevFjxhKt0paCkRDTZiczKb7F4yTgRP8M4JdVkpQwmaD4EoJf6qA+p61godDokw==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2058,14 +2058,14 @@
       "version": "6.19.0-26.2ba551f319ab1df4bc874a89965d8b3641056773",
       "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.19.0-26.2ba551f319ab1df4bc874a89965d8b3641056773.tgz",
       "integrity": "sha512-gV7uOBQfAFlWDvPJdQxMT1aSRur3a0EkU/6cfbAC5isV67tKDWUrPauyaHNpB+wN1ebM4A9jn/f4gH+3iHSYSQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
       "version": "6.19.0",
       "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.19.0.tgz",
       "integrity": "sha512-OOx2Lda0DGrZ1rodADT06ZGqHzr7HY7LNMaFE2Vp8dp146uJld58sRuasdX0OiwpHgl8SqDTUKHNUyzEq7pDdQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "6.19.0",
@@ -2077,7 +2077,7 @@
       "version": "6.19.0",
       "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.19.0.tgz",
       "integrity": "sha512-ym85WDO2yDhC3fIXHWYpG3kVMBA49cL1XD2GCsCF8xbwoy2OkDQY44gEbAt2X46IQ4Apq9H6g0Ex1iFfPqEkHA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "6.19.0"
@@ -2420,7 +2420,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
       "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -2933,7 +2933,6 @@
       "version": "19.2.2",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.2.tgz",
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
-      "dev": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -3955,7 +3954,7 @@
       "version": "2.8.25",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.25.tgz",
       "integrity": "sha512-2NovHVesVF5TXefsGX1yzx1xgr7+m9JQenvz6FQY3qd+YXkKkYiv+vTCc7OriP9mcDZpTC5mAOYN4ocd29+erA==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
       }
@@ -3996,7 +3995,7 @@
       "version": "4.27.0",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.27.0.tgz",
       "integrity": "sha512-AXVQwdhot1eqLihwasPElhX2tAZiBjWdJ9i/Zcj2S6QYIjkx62OKSfnobkriB81C3l4w0rVy3Nt4jaTBltYEpw==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4029,7 +4028,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/c12/-/c12-3.1.0.tgz",
       "integrity": "sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": "^4.0.3",
@@ -4159,7 +4158,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -4175,7 +4174,7 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
       "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "consola": "^3.2.3"
@@ -4293,14 +4292,14 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
       "integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/consola": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
       "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^14.18.0 || >=16.10.0"
@@ -4310,7 +4309,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/cookie": {
       "version": "0.7.2",
@@ -4464,7 +4463,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -4494,7 +4493,7 @@
       "version": "7.1.5",
       "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
       "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=16.0.0"
@@ -4538,7 +4537,7 @@
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
       "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/delayed-stream": {
@@ -4565,7 +4564,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
       "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/detect-libc": {
@@ -4611,7 +4610,7 @@
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
       "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -4638,7 +4637,7 @@
       "version": "3.18.4",
       "resolved": "https://registry.npmjs.org/effect/-/effect-3.18.4.tgz",
       "integrity": "sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
@@ -4649,7 +4648,7 @@
       "version": "1.5.249",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.249.tgz",
       "integrity": "sha512-5vcfL3BBe++qZ5kuFhD/p8WOM1N9m3nwvJPULJx+4xf2usSlZFJ0qoNYO2fOX4hi3ocuDcmDobtA+5SFr4OmBg==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -4661,7 +4660,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
       "integrity": "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -4991,7 +4990,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=6"
       }
@@ -5435,14 +5434,14 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.7.tgz",
       "integrity": "sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/fast-check": {
       "version": "3.23.2",
       "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
       "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "individual",
@@ -5711,7 +5710,7 @@
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -5795,7 +5794,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/giget/-/giget-2.0.0.tgz",
       "integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "citty": "^0.1.6",
@@ -6541,7 +6540,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -6613,7 +6612,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -6693,7 +6692,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -6723,7 +6722,7 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -7113,7 +7112,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "yallist": "^3.0.2"
       }
@@ -7409,20 +7408,20 @@
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
       "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/node-releases": {
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/nypm": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.2.tgz",
       "integrity": "sha512-7eM+hpOtrKrBDCh7Ypu2lJ9Z7PNZBdi/8AT3AX8xoCj43BBVHD0hPSTEvMtkMpfs8FCqBGhxB+uToIQimA111g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "citty": "^0.1.6",
@@ -7564,7 +7563,7 @@
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
       "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/optionator": {
@@ -7684,14 +7683,14 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/perfect-debounce": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
       "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -7716,7 +7715,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
       "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "confbox": "^0.2.2",
@@ -7791,7 +7790,7 @@
       "version": "6.19.0",
       "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.19.0.tgz",
       "integrity": "sha512-F3eX7K+tWpkbhl3l4+VkFtrwJlLXbAM+f9jolgoUZbFcm1DgHZ4cq9AgVEgUym2au5Ad/TDLN8lg83D+M10ycw==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -7844,7 +7843,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
       "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "individual",
@@ -7892,7 +7891,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
       "integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "defu": "^6.1.4",
@@ -8076,7 +8075,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -8099,6 +8098,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -8346,7 +8352,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -8955,7 +8961,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
       "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -9188,7 +9194,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9287,7 +9293,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.4.tgz",
       "integrity": "sha512-q0SPT4xyU84saUX+tomz1WLkxUbuaJnR1xWt17M7fJtEJigJeWUNGUqrauFXsHnqev9y9JTRGwk13tFBuKby4A==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -9815,7 +9821,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/src/components/richmenu/AreaActionForm.tsx
+++ b/src/components/richmenu/AreaActionForm.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import type { TapArea } from "@/types/richmenu";
+
+interface AreaActionFormProps {
+  area: TapArea;
+  onUpdate: (updates: Partial<TapArea>) => void;
+}
+
+export function AreaActionForm({ area, onUpdate }: AreaActionFormProps) {
+  return (
+    <div className="space-y-2">
+      <select
+        value={area.action.type}
+        onChange={(e) =>
+          onUpdate({
+            action: {
+              type: e.target.value as "uri" | "message" | "postback",
+              ...(e.target.value === "uri" && { uri: "https://example.com" }),
+              ...(e.target.value === "message" && { text: "メッセージ" }),
+              ...(e.target.value === "postback" && { data: "action=example" }),
+            },
+          })
+        }
+        className="w-full rounded border border-slate-600 bg-slate-900/60 px-2 py-1.5 text-sm text-white"
+      >
+        <option value="uri">リンク (URI)</option>
+        <option value="message">メッセージ</option>
+        <option value="postback">ポストバック</option>
+      </select>
+
+      {area.action.type === "uri" && (
+        <input
+          type="url"
+          value={area.action.uri || ""}
+          onChange={(e) =>
+            onUpdate({
+              action: { ...area.action, uri: e.target.value },
+            })
+          }
+          className="w-full rounded border border-slate-600 bg-slate-900/60 px-2 py-1.5 text-sm text-white placeholder-slate-500"
+          placeholder="https://example.com"
+          required
+        />
+      )}
+
+      {area.action.type === "message" && (
+        <input
+          type="text"
+          value={area.action.text || ""}
+          onChange={(e) =>
+            onUpdate({
+              action: { ...area.action, text: e.target.value },
+            })
+          }
+          className="w-full rounded border border-slate-600 bg-slate-900/60 px-2 py-1.5 text-sm text-white placeholder-slate-500"
+          placeholder="送信されるテキスト"
+          required
+        />
+      )}
+
+      {area.action.type === "postback" && (
+        <input
+          type="text"
+          value={area.action.data || ""}
+          onChange={(e) =>
+            onUpdate({
+              action: { ...area.action, data: e.target.value },
+            })
+          }
+          className="w-full rounded border border-slate-600 bg-slate-900/60 px-2 py-1.5 text-sm text-white placeholder-slate-500"
+          placeholder="action=example&id=123"
+          required
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/richmenu/AreaItem.tsx
+++ b/src/components/richmenu/AreaItem.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { Trash2, Edit2 } from "lucide-react";
+import type { TapArea } from "@/types/richmenu";
+import { AREA_COLORS } from "@/constants/richmenu";
+import { AreaActionForm } from "./AreaActionForm";
+
+interface AreaItemProps {
+  area: TapArea;
+  index: number;
+  isSelected: boolean;
+  onSelect: () => void;
+  onDelete: () => void;
+  onUpdate: (updates: Partial<TapArea>) => void;
+}
+
+export function AreaItem({
+  area,
+  index,
+  isSelected,
+  onSelect,
+  onDelete,
+  onUpdate,
+}: AreaItemProps) {
+  return (
+    <div
+      className={`rounded-lg border p-4 transition-colors ${
+        isSelected
+          ? "border-blue-500 bg-blue-500/10"
+          : "border-slate-700/50 bg-slate-900/40"
+      }`}
+    >
+      <div className="flex items-start justify-between">
+        <div className="flex-1 space-y-3">
+          <div className="flex items-center gap-2">
+            <div
+              className="h-4 w-4 rounded"
+              style={{ backgroundColor: AREA_COLORS[index % AREA_COLORS.length] }}
+            />
+            <span className="text-sm font-medium text-slate-300">エリア {index + 1}</span>
+            <span className="text-xs text-slate-500">
+              ({area.bounds.x}, {area.bounds.y}) - {area.bounds.width}×{area.bounds.height}
+            </span>
+          </div>
+
+          <AreaActionForm area={area} onUpdate={onUpdate} />
+        </div>
+
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={onSelect}
+            className="p-2 text-slate-400 hover:text-blue-400 transition-colors"
+            title="選択"
+          >
+            <Edit2 className="h-4 w-4" />
+          </button>
+          <button
+            type="button"
+            onClick={onDelete}
+            className="p-2 text-slate-400 hover:text-red-400 transition-colors"
+            title="削除"
+          >
+            <Trash2 className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/richmenu/AreaList.tsx
+++ b/src/components/richmenu/AreaList.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { Plus } from "lucide-react";
+import type { TapArea } from "@/types/richmenu";
+import { AreaItem } from "./AreaItem";
+
+interface AreaListProps {
+  areas: TapArea[];
+  selectedAreaIndex: number | null;
+  onSelectArea: (index: number) => void;
+  onDeleteArea: (index: number) => void;
+  onUpdateArea: (index: number, updates: Partial<TapArea>) => void;
+}
+
+export function AreaList({
+  areas,
+  selectedAreaIndex,
+  onSelectArea,
+  onDeleteArea,
+  onUpdateArea,
+}: AreaListProps) {
+  if (areas.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed border-slate-600 bg-slate-900/40 p-8 text-center">
+        <Plus className="mx-auto h-8 w-8 text-slate-500 mb-2" />
+        <p className="text-sm text-slate-400">画像上をドラッグしてタップ領域を作成</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {areas.map((area, index) => (
+        <AreaItem
+          key={index}
+          area={area}
+          index={index}
+          isSelected={selectedAreaIndex === index}
+          onSelect={() => onSelectArea(index)}
+          onDelete={() => onDeleteArea(index)}
+          onUpdate={(updates) => onUpdateArea(index, updates)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/richmenu/RichMenuCanvas.tsx
+++ b/src/components/richmenu/RichMenuCanvas.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { RefObject } from "react";
+import type { TapArea, RichMenuSize, Point } from "@/types/richmenu";
+import { useCanvasDrawing } from "@/hooks/useCanvasDrawing";
+
+interface RichMenuCanvasProps {
+  containerRef: RefObject<HTMLDivElement | null>;
+  canvasRef: RefObject<HTMLCanvasElement | null>;
+  image: HTMLImageElement | null;
+  richMenuSize: RichMenuSize;
+  scale: number;
+  areas: TapArea[];
+  selectedAreaIndex: number | null;
+  isDrawing: boolean;
+  drawStart: Point | null;
+  currentDraw: Point | null;
+  onMouseDown: (e: React.MouseEvent<HTMLCanvasElement>) => void;
+  onMouseMove: (e: React.MouseEvent<HTMLCanvasElement>) => void;
+  onMouseUp: (e: React.MouseEvent<HTMLCanvasElement>) => void;
+  onMouseLeave: () => void;
+}
+
+export function RichMenuCanvas({
+  containerRef,
+  canvasRef,
+  image,
+  richMenuSize,
+  scale,
+  areas,
+  selectedAreaIndex,
+  isDrawing,
+  drawStart,
+  currentDraw,
+  onMouseDown,
+  onMouseMove,
+  onMouseUp,
+  onMouseLeave,
+}: RichMenuCanvasProps) {
+  useCanvasDrawing({
+    canvasRef,
+    image,
+    richMenuSize,
+    scale,
+    areas,
+    selectedAreaIndex,
+    isDrawing,
+    drawStart,
+    currentDraw,
+  });
+
+  return (
+    <div ref={containerRef} className="rounded-lg border border-slate-700/50 bg-slate-900/40 p-4">
+      <canvas
+        ref={canvasRef}
+        onMouseDown={onMouseDown}
+        onMouseMove={onMouseMove}
+        onMouseUp={onMouseUp}
+        onMouseLeave={onMouseLeave}
+        className="w-full cursor-crosshair rounded border border-slate-600"
+      />
+    </div>
+  );
+}

--- a/src/components/richmenu/VisualEditor.original.tsx
+++ b/src/components/richmenu/VisualEditor.original.tsx
@@ -1,0 +1,392 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import { Trash2, Edit2, Plus } from "lucide-react";
+
+interface TapArea {
+  bounds: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  };
+  action: {
+    type: "uri" | "message" | "postback";
+    label?: string;
+    uri?: string;
+    text?: string;
+    data?: string;
+  };
+}
+
+interface VisualEditorProps {
+  imageUrl: string;
+  size: "full" | "half";
+  areas: TapArea[];
+  onAreasChange: (areas: TapArea[]) => void;
+}
+
+const RICHMENU_SIZES = {
+  full: { width: 2500, height: 1686 },
+  half: { width: 2500, height: 843 },
+};
+
+const COLORS = [
+  "rgba(59, 130, 246, 0.3)", // blue
+  "rgba(239, 68, 68, 0.3)", // red
+  "rgba(34, 197, 94, 0.3)", // green
+  "rgba(234, 179, 8, 0.3)", // yellow
+  "rgba(168, 85, 247, 0.3)", // purple
+  "rgba(236, 72, 153, 0.3)", // pink
+];
+
+export function VisualEditor({ imageUrl, size, areas, onAreasChange }: VisualEditorProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [selectedAreaIndex, setSelectedAreaIndex] = useState<number | null>(null);
+  const [isDrawing, setIsDrawing] = useState(false);
+  const [drawStart, setDrawStart] = useState<{ x: number; y: number } | null>(null);
+  const [currentDraw, setCurrentDraw] = useState<{ x: number; y: number } | null>(null);
+  const [scale, setScale] = useState(1);
+  const [image, setImage] = useState<HTMLImageElement | null>(null);
+
+  const richMenuSize = RICHMENU_SIZES[size];
+
+  // Load image
+  useEffect(() => {
+    if (!imageUrl) {
+      setImage(null);
+      return;
+    }
+
+    const img = new Image();
+    img.crossOrigin = "anonymous";
+    img.onload = () => {
+      setImage(img);
+      updateScale();
+    };
+    img.src = imageUrl;
+  }, [imageUrl]);
+
+  // Update scale when container size changes
+  useEffect(() => {
+    const handleResize = () => updateScale();
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  const updateScale = () => {
+    if (!containerRef.current) return;
+    const containerWidth = containerRef.current.clientWidth;
+    const newScale = Math.min(containerWidth / richMenuSize.width, 1);
+    setScale(newScale);
+  };
+
+  // Draw canvas
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || !image) return;
+
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    // Set canvas size
+    canvas.width = richMenuSize.width * scale;
+    canvas.height = richMenuSize.height * scale;
+
+    // Draw image
+    ctx.drawImage(image, 0, 0, canvas.width, canvas.height);
+
+    // Draw existing areas
+    areas.forEach((area, index) => {
+      const isSelected = index === selectedAreaIndex;
+      ctx.fillStyle = COLORS[index % COLORS.length];
+      ctx.fillRect(
+        area.bounds.x * scale,
+        area.bounds.y * scale,
+        area.bounds.width * scale,
+        area.bounds.height * scale
+      );
+
+      // Draw border
+      ctx.strokeStyle = isSelected ? "#3b82f6" : "#ffffff";
+      ctx.lineWidth = isSelected ? 3 : 2;
+      ctx.strokeRect(
+        area.bounds.x * scale,
+        area.bounds.y * scale,
+        area.bounds.width * scale,
+        area.bounds.height * scale
+      );
+
+      // Draw label
+      ctx.fillStyle = "#ffffff";
+      ctx.font = `bold ${14 * scale}px sans-serif`;
+      ctx.fillText(
+        `Area ${index + 1}`,
+        area.bounds.x * scale + 5,
+        area.bounds.y * scale + 20 * scale
+      );
+    });
+
+    // Draw current drawing area
+    if (isDrawing && drawStart && currentDraw) {
+      const x = Math.min(drawStart.x, currentDraw.x);
+      const y = Math.min(drawStart.y, currentDraw.y);
+      const width = Math.abs(currentDraw.x - drawStart.x);
+      const height = Math.abs(currentDraw.y - drawStart.y);
+
+      ctx.fillStyle = "rgba(59, 130, 246, 0.3)";
+      ctx.fillRect(x, y, width, height);
+      ctx.strokeStyle = "#3b82f6";
+      ctx.lineWidth = 2;
+      ctx.strokeRect(x, y, width, height);
+    }
+  }, [image, areas, selectedAreaIndex, isDrawing, drawStart, currentDraw, scale, richMenuSize]);
+
+  const getCanvasCoordinates = (e: React.MouseEvent<HTMLCanvasElement>) => {
+    const canvas = canvasRef.current;
+    if (!canvas) return { x: 0, y: 0 };
+
+    const rect = canvas.getBoundingClientRect();
+    return {
+      x: e.clientX - rect.left,
+      y: e.clientY - rect.top,
+    };
+  };
+
+  const handleMouseDown = (e: React.MouseEvent<HTMLCanvasElement>) => {
+    const coords = getCanvasCoordinates(e);
+
+    // Check if clicking on existing area
+    const clickedIndex = areas.findIndex((area) => {
+      const x = area.bounds.x * scale;
+      const y = area.bounds.y * scale;
+      const w = area.bounds.width * scale;
+      const h = area.bounds.height * scale;
+      return coords.x >= x && coords.x <= x + w && coords.y >= y && coords.y <= y + h;
+    });
+
+    if (clickedIndex !== -1) {
+      setSelectedAreaIndex(clickedIndex);
+      return;
+    }
+
+    // Start drawing new area
+    setSelectedAreaIndex(null);
+    setIsDrawing(true);
+    setDrawStart(coords);
+    setCurrentDraw(coords);
+  };
+
+  const handleMouseMove = (e: React.MouseEvent<HTMLCanvasElement>) => {
+    if (!isDrawing) return;
+    setCurrentDraw(getCanvasCoordinates(e));
+  };
+
+  const handleMouseUp = (e: React.MouseEvent<HTMLCanvasElement>) => {
+    if (!isDrawing || !drawStart) return;
+
+    const coords = getCanvasCoordinates(e);
+    const x = Math.min(drawStart.x, coords.x) / scale;
+    const y = Math.min(drawStart.y, coords.y) / scale;
+    const width = Math.abs(coords.x - drawStart.x) / scale;
+    const height = Math.abs(coords.y - drawStart.y) / scale;
+
+    // Only add area if it has meaningful size
+    if (width > 10 && height > 10) {
+      const newArea: TapArea = {
+        bounds: {
+          x: Math.round(x),
+          y: Math.round(y),
+          width: Math.round(width),
+          height: Math.round(height),
+        },
+        action: {
+          type: "uri",
+          uri: "https://example.com",
+        },
+      };
+      onAreasChange([...areas, newArea]);
+      setSelectedAreaIndex(areas.length);
+    }
+
+    setIsDrawing(false);
+    setDrawStart(null);
+    setCurrentDraw(null);
+  };
+
+  const handleDeleteArea = (index: number) => {
+    onAreasChange(areas.filter((_, i) => i !== index));
+    if (selectedAreaIndex === index) {
+      setSelectedAreaIndex(null);
+    } else if (selectedAreaIndex !== null && selectedAreaIndex > index) {
+      setSelectedAreaIndex(selectedAreaIndex - 1);
+    }
+  };
+
+  const handleUpdateArea = (index: number, updates: Partial<TapArea>) => {
+    const newAreas = [...areas];
+    newAreas[index] = { ...newAreas[index], ...updates };
+    onAreasChange(newAreas);
+  };
+
+  if (!imageUrl) {
+    return (
+      <div className="rounded-lg border-2 border-dashed border-slate-600 bg-slate-900/40 p-12 text-center">
+        <p className="text-slate-400">画像をアップロードしてタップ領域を設定してください</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <label className="text-sm font-medium text-slate-300">
+          タップ領域 <span className="text-red-400">*</span>
+        </label>
+        <div className="text-xs text-slate-500">
+          画像上をドラッグして領域を作成、クリックして選択
+        </div>
+      </div>
+
+      <div ref={containerRef} className="rounded-lg border border-slate-700/50 bg-slate-900/40 p-4">
+        <canvas
+          ref={canvasRef}
+          onMouseDown={handleMouseDown}
+          onMouseMove={handleMouseMove}
+          onMouseUp={handleMouseUp}
+          onMouseLeave={() => {
+            if (isDrawing) {
+              setIsDrawing(false);
+              setDrawStart(null);
+              setCurrentDraw(null);
+            }
+          }}
+          className="w-full cursor-crosshair rounded border border-slate-600"
+        />
+      </div>
+
+      {/* Area List */}
+      <div className="space-y-2">
+        {areas.map((area, index) => (
+          <div
+            key={index}
+            className={`rounded-lg border p-4 transition-colors ${
+              selectedAreaIndex === index
+                ? "border-blue-500 bg-blue-500/10"
+                : "border-slate-700/50 bg-slate-900/40"
+            }`}
+          >
+            <div className="flex items-start justify-between">
+              <div className="flex-1 space-y-3">
+                <div className="flex items-center gap-2">
+                  <div
+                    className="h-4 w-4 rounded"
+                    style={{ backgroundColor: COLORS[index % COLORS.length] }}
+                  />
+                  <span className="text-sm font-medium text-slate-300">エリア {index + 1}</span>
+                  <span className="text-xs text-slate-500">
+                    ({area.bounds.x}, {area.bounds.y}) - {area.bounds.width}×{area.bounds.height}
+                  </span>
+                </div>
+
+                {/* Action Type */}
+                <div className="space-y-2">
+                  <select
+                    value={area.action.type}
+                    onChange={(e) =>
+                      handleUpdateArea(index, {
+                        action: {
+                          type: e.target.value as "uri" | "message" | "postback",
+                          ...(e.target.value === "uri" && { uri: "https://example.com" }),
+                          ...(e.target.value === "message" && { text: "メッセージ" }),
+                          ...(e.target.value === "postback" && { data: "action=example" }),
+                        },
+                      })
+                    }
+                    className="w-full rounded border border-slate-600 bg-slate-900/60 px-2 py-1.5 text-sm text-white"
+                  >
+                    <option value="uri">リンク (URI)</option>
+                    <option value="message">メッセージ</option>
+                    <option value="postback">ポストバック</option>
+                  </select>
+
+                  {area.action.type === "uri" && (
+                    <input
+                      type="url"
+                      value={area.action.uri || ""}
+                      onChange={(e) =>
+                        handleUpdateArea(index, {
+                          action: { ...area.action, uri: e.target.value },
+                        })
+                      }
+                      className="w-full rounded border border-slate-600 bg-slate-900/60 px-2 py-1.5 text-sm text-white placeholder-slate-500"
+                      placeholder="https://example.com"
+                      required
+                    />
+                  )}
+
+                  {area.action.type === "message" && (
+                    <input
+                      type="text"
+                      value={area.action.text || ""}
+                      onChange={(e) =>
+                        handleUpdateArea(index, {
+                          action: { ...area.action, text: e.target.value },
+                        })
+                      }
+                      className="w-full rounded border border-slate-600 bg-slate-900/60 px-2 py-1.5 text-sm text-white placeholder-slate-500"
+                      placeholder="送信されるテキスト"
+                      required
+                    />
+                  )}
+
+                  {area.action.type === "postback" && (
+                    <input
+                      type="text"
+                      value={area.action.data || ""}
+                      onChange={(e) =>
+                        handleUpdateArea(index, {
+                          action: { ...area.action, data: e.target.value },
+                        })
+                      }
+                      className="w-full rounded border border-slate-600 bg-slate-900/60 px-2 py-1.5 text-sm text-white placeholder-slate-500"
+                      placeholder="action=example&id=123"
+                      required
+                    />
+                  )}
+                </div>
+              </div>
+
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => setSelectedAreaIndex(index)}
+                  className="p-2 text-slate-400 hover:text-blue-400 transition-colors"
+                  title="選択"
+                >
+                  <Edit2 className="h-4 w-4" />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => handleDeleteArea(index)}
+                  className="p-2 text-slate-400 hover:text-red-400 transition-colors"
+                  title="削除"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </button>
+              </div>
+            </div>
+          </div>
+        ))}
+
+        {areas.length === 0 && (
+          <div className="rounded-lg border border-dashed border-slate-600 bg-slate-900/40 p-8 text-center">
+            <Plus className="mx-auto h-8 w-8 text-slate-500 mb-2" />
+            <p className="text-sm text-slate-400">画像上をドラッグしてタップ領域を作成</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/richmenu/VisualEditor.tsx
+++ b/src/components/richmenu/VisualEditor.tsx
@@ -1,56 +1,46 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
-import { Trash2, Edit2, Plus } from "lucide-react";
-
-interface TapArea {
-  bounds: {
-    x: number;
-    y: number;
-    width: number;
-    height: number;
-  };
-  action: {
-    type: "uri" | "message" | "postback";
-    label?: string;
-    uri?: string;
-    text?: string;
-    data?: string;
-  };
-}
+import type { TapArea, RichMenuSizeType } from "@/types/richmenu";
+import { RICHMENU_SIZES } from "@/constants/richmenu";
+import { useCanvasScale } from "@/hooks/useCanvasScale";
+import { useAreaSelection } from "@/hooks/useAreaSelection";
+import { RichMenuCanvas } from "./RichMenuCanvas";
+import { AreaList } from "./AreaList";
 
 interface VisualEditorProps {
   imageUrl: string;
-  size: "full" | "half";
+  size: RichMenuSizeType;
   areas: TapArea[];
   onAreasChange: (areas: TapArea[]) => void;
 }
 
-const RICHMENU_SIZES = {
-  full: { width: 2500, height: 1686 },
-  half: { width: 2500, height: 843 },
-};
-
-const COLORS = [
-  "rgba(59, 130, 246, 0.3)", // blue
-  "rgba(239, 68, 68, 0.3)", // red
-  "rgba(34, 197, 94, 0.3)", // green
-  "rgba(234, 179, 8, 0.3)", // yellow
-  "rgba(168, 85, 247, 0.3)", // purple
-  "rgba(236, 72, 153, 0.3)", // pink
-];
-
 export function VisualEditor({ imageUrl, size, areas, onAreasChange }: VisualEditorProps) {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
-  const [selectedAreaIndex, setSelectedAreaIndex] = useState<number | null>(null);
-  const [isDrawing, setIsDrawing] = useState(false);
-  const [drawStart, setDrawStart] = useState<{ x: number; y: number } | null>(null);
-  const [currentDraw, setCurrentDraw] = useState<{ x: number; y: number } | null>(null);
-  const [scale, setScale] = useState(1);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
   const [image, setImage] = useState<HTMLImageElement | null>(null);
 
   const richMenuSize = RICHMENU_SIZES[size];
+  const scale = useCanvasScale(containerRef, richMenuSize);
+
+  const {
+    selectedAreaIndex,
+    setSelectedAreaIndex,
+    isDrawing,
+    drawStart,
+    currentDraw,
+    handleMouseDown,
+    handleMouseMove,
+    handleMouseUp,
+    handleMouseLeave,
+    handleDeleteArea,
+    handleUpdateArea,
+  } = useAreaSelection({
+    canvasRef,
+    areas,
+    onAreasChange,
+    scale,
+  });
 
   // Load image
   useEffect(() => {
@@ -63,172 +53,9 @@ export function VisualEditor({ imageUrl, size, areas, onAreasChange }: VisualEdi
     img.crossOrigin = "anonymous";
     img.onload = () => {
       setImage(img);
-      updateScale();
     };
     img.src = imageUrl;
   }, [imageUrl]);
-
-  // Update scale when container size changes
-  useEffect(() => {
-    const handleResize = () => updateScale();
-    window.addEventListener("resize", handleResize);
-    return () => window.removeEventListener("resize", handleResize);
-  }, []);
-
-  const updateScale = () => {
-    if (!containerRef.current) return;
-    const containerWidth = containerRef.current.clientWidth;
-    const newScale = Math.min(containerWidth / richMenuSize.width, 1);
-    setScale(newScale);
-  };
-
-  // Draw canvas
-  useEffect(() => {
-    const canvas = canvasRef.current;
-    if (!canvas || !image) return;
-
-    const ctx = canvas.getContext("2d");
-    if (!ctx) return;
-
-    // Set canvas size
-    canvas.width = richMenuSize.width * scale;
-    canvas.height = richMenuSize.height * scale;
-
-    // Draw image
-    ctx.drawImage(image, 0, 0, canvas.width, canvas.height);
-
-    // Draw existing areas
-    areas.forEach((area, index) => {
-      const isSelected = index === selectedAreaIndex;
-      ctx.fillStyle = COLORS[index % COLORS.length];
-      ctx.fillRect(
-        area.bounds.x * scale,
-        area.bounds.y * scale,
-        area.bounds.width * scale,
-        area.bounds.height * scale
-      );
-
-      // Draw border
-      ctx.strokeStyle = isSelected ? "#3b82f6" : "#ffffff";
-      ctx.lineWidth = isSelected ? 3 : 2;
-      ctx.strokeRect(
-        area.bounds.x * scale,
-        area.bounds.y * scale,
-        area.bounds.width * scale,
-        area.bounds.height * scale
-      );
-
-      // Draw label
-      ctx.fillStyle = "#ffffff";
-      ctx.font = `bold ${14 * scale}px sans-serif`;
-      ctx.fillText(
-        `Area ${index + 1}`,
-        area.bounds.x * scale + 5,
-        area.bounds.y * scale + 20 * scale
-      );
-    });
-
-    // Draw current drawing area
-    if (isDrawing && drawStart && currentDraw) {
-      const x = Math.min(drawStart.x, currentDraw.x);
-      const y = Math.min(drawStart.y, currentDraw.y);
-      const width = Math.abs(currentDraw.x - drawStart.x);
-      const height = Math.abs(currentDraw.y - drawStart.y);
-
-      ctx.fillStyle = "rgba(59, 130, 246, 0.3)";
-      ctx.fillRect(x, y, width, height);
-      ctx.strokeStyle = "#3b82f6";
-      ctx.lineWidth = 2;
-      ctx.strokeRect(x, y, width, height);
-    }
-  }, [image, areas, selectedAreaIndex, isDrawing, drawStart, currentDraw, scale, richMenuSize]);
-
-  const getCanvasCoordinates = (e: React.MouseEvent<HTMLCanvasElement>) => {
-    const canvas = canvasRef.current;
-    if (!canvas) return { x: 0, y: 0 };
-
-    const rect = canvas.getBoundingClientRect();
-    return {
-      x: e.clientX - rect.left,
-      y: e.clientY - rect.top,
-    };
-  };
-
-  const handleMouseDown = (e: React.MouseEvent<HTMLCanvasElement>) => {
-    const coords = getCanvasCoordinates(e);
-
-    // Check if clicking on existing area
-    const clickedIndex = areas.findIndex((area) => {
-      const x = area.bounds.x * scale;
-      const y = area.bounds.y * scale;
-      const w = area.bounds.width * scale;
-      const h = area.bounds.height * scale;
-      return coords.x >= x && coords.x <= x + w && coords.y >= y && coords.y <= y + h;
-    });
-
-    if (clickedIndex !== -1) {
-      setSelectedAreaIndex(clickedIndex);
-      return;
-    }
-
-    // Start drawing new area
-    setSelectedAreaIndex(null);
-    setIsDrawing(true);
-    setDrawStart(coords);
-    setCurrentDraw(coords);
-  };
-
-  const handleMouseMove = (e: React.MouseEvent<HTMLCanvasElement>) => {
-    if (!isDrawing) return;
-    setCurrentDraw(getCanvasCoordinates(e));
-  };
-
-  const handleMouseUp = (e: React.MouseEvent<HTMLCanvasElement>) => {
-    if (!isDrawing || !drawStart) return;
-
-    const coords = getCanvasCoordinates(e);
-    const x = Math.min(drawStart.x, coords.x) / scale;
-    const y = Math.min(drawStart.y, coords.y) / scale;
-    const width = Math.abs(coords.x - drawStart.x) / scale;
-    const height = Math.abs(coords.y - drawStart.y) / scale;
-
-    // Only add area if it has meaningful size
-    if (width > 10 && height > 10) {
-      const newArea: TapArea = {
-        bounds: {
-          x: Math.round(x),
-          y: Math.round(y),
-          width: Math.round(width),
-          height: Math.round(height),
-        },
-        action: {
-          type: "uri",
-          uri: "https://example.com",
-        },
-      };
-      onAreasChange([...areas, newArea]);
-      setSelectedAreaIndex(areas.length);
-    }
-
-    setIsDrawing(false);
-    setDrawStart(null);
-    setCurrentDraw(null);
-  };
-
-  const handleDeleteArea = (index: number) => {
-    onAreasChange(areas.filter((_, i) => i !== index));
-    if (selectedAreaIndex === index) {
-      setSelectedAreaIndex(null);
-    } else if (selectedAreaIndex !== null && selectedAreaIndex > index) {
-      setSelectedAreaIndex(selectedAreaIndex - 1);
-    }
-  };
-
-  const handleUpdateArea = (index: number, updates: Partial<TapArea>) => {
-    const newAreas = [...areas];
-    newAreas[index] = { ...newAreas[index], ...updates };
-    onAreasChange(newAreas);
-  };
 
   if (!imageUrl) {
     return (
@@ -249,144 +76,30 @@ export function VisualEditor({ imageUrl, size, areas, onAreasChange }: VisualEdi
         </div>
       </div>
 
-      <div ref={containerRef} className="rounded-lg border border-slate-700/50 bg-slate-900/40 p-4">
-        <canvas
-          ref={canvasRef}
-          onMouseDown={handleMouseDown}
-          onMouseMove={handleMouseMove}
-          onMouseUp={handleMouseUp}
-          onMouseLeave={() => {
-            if (isDrawing) {
-              setIsDrawing(false);
-              setDrawStart(null);
-              setCurrentDraw(null);
-            }
-          }}
-          className="w-full cursor-crosshair rounded border border-slate-600"
-        />
-      </div>
+      <RichMenuCanvas
+        containerRef={containerRef}
+        canvasRef={canvasRef}
+        image={image}
+        richMenuSize={richMenuSize}
+        scale={scale}
+        areas={areas}
+        selectedAreaIndex={selectedAreaIndex}
+        isDrawing={isDrawing}
+        drawStart={drawStart}
+        currentDraw={currentDraw}
+        onMouseDown={handleMouseDown}
+        onMouseMove={handleMouseMove}
+        onMouseUp={handleMouseUp}
+        onMouseLeave={handleMouseLeave}
+      />
 
-      {/* Area List */}
-      <div className="space-y-2">
-        {areas.map((area, index) => (
-          <div
-            key={index}
-            className={`rounded-lg border p-4 transition-colors ${
-              selectedAreaIndex === index
-                ? "border-blue-500 bg-blue-500/10"
-                : "border-slate-700/50 bg-slate-900/40"
-            }`}
-          >
-            <div className="flex items-start justify-between">
-              <div className="flex-1 space-y-3">
-                <div className="flex items-center gap-2">
-                  <div
-                    className="h-4 w-4 rounded"
-                    style={{ backgroundColor: COLORS[index % COLORS.length] }}
-                  />
-                  <span className="text-sm font-medium text-slate-300">エリア {index + 1}</span>
-                  <span className="text-xs text-slate-500">
-                    ({area.bounds.x}, {area.bounds.y}) - {area.bounds.width}×{area.bounds.height}
-                  </span>
-                </div>
-
-                {/* Action Type */}
-                <div className="space-y-2">
-                  <select
-                    value={area.action.type}
-                    onChange={(e) =>
-                      handleUpdateArea(index, {
-                        action: {
-                          type: e.target.value as "uri" | "message" | "postback",
-                          ...(e.target.value === "uri" && { uri: "https://example.com" }),
-                          ...(e.target.value === "message" && { text: "メッセージ" }),
-                          ...(e.target.value === "postback" && { data: "action=example" }),
-                        },
-                      })
-                    }
-                    className="w-full rounded border border-slate-600 bg-slate-900/60 px-2 py-1.5 text-sm text-white"
-                  >
-                    <option value="uri">リンク (URI)</option>
-                    <option value="message">メッセージ</option>
-                    <option value="postback">ポストバック</option>
-                  </select>
-
-                  {area.action.type === "uri" && (
-                    <input
-                      type="url"
-                      value={area.action.uri || ""}
-                      onChange={(e) =>
-                        handleUpdateArea(index, {
-                          action: { ...area.action, uri: e.target.value },
-                        })
-                      }
-                      className="w-full rounded border border-slate-600 bg-slate-900/60 px-2 py-1.5 text-sm text-white placeholder-slate-500"
-                      placeholder="https://example.com"
-                      required
-                    />
-                  )}
-
-                  {area.action.type === "message" && (
-                    <input
-                      type="text"
-                      value={area.action.text || ""}
-                      onChange={(e) =>
-                        handleUpdateArea(index, {
-                          action: { ...area.action, text: e.target.value },
-                        })
-                      }
-                      className="w-full rounded border border-slate-600 bg-slate-900/60 px-2 py-1.5 text-sm text-white placeholder-slate-500"
-                      placeholder="送信されるテキスト"
-                      required
-                    />
-                  )}
-
-                  {area.action.type === "postback" && (
-                    <input
-                      type="text"
-                      value={area.action.data || ""}
-                      onChange={(e) =>
-                        handleUpdateArea(index, {
-                          action: { ...area.action, data: e.target.value },
-                        })
-                      }
-                      className="w-full rounded border border-slate-600 bg-slate-900/60 px-2 py-1.5 text-sm text-white placeholder-slate-500"
-                      placeholder="action=example&id=123"
-                      required
-                    />
-                  )}
-                </div>
-              </div>
-
-              <div className="flex gap-2">
-                <button
-                  type="button"
-                  onClick={() => setSelectedAreaIndex(index)}
-                  className="p-2 text-slate-400 hover:text-blue-400 transition-colors"
-                  title="選択"
-                >
-                  <Edit2 className="h-4 w-4" />
-                </button>
-                <button
-                  type="button"
-                  onClick={() => handleDeleteArea(index)}
-                  className="p-2 text-slate-400 hover:text-red-400 transition-colors"
-                  title="削除"
-                >
-                  <Trash2 className="h-4 w-4" />
-                </button>
-              </div>
-            </div>
-          </div>
-        ))}
-
-        {areas.length === 0 && (
-          <div className="rounded-lg border border-dashed border-slate-600 bg-slate-900/40 p-8 text-center">
-            <Plus className="mx-auto h-8 w-8 text-slate-500 mb-2" />
-            <p className="text-sm text-slate-400">画像上をドラッグしてタップ領域を作成</p>
-          </div>
-        )}
-      </div>
+      <AreaList
+        areas={areas}
+        selectedAreaIndex={selectedAreaIndex}
+        onSelectArea={setSelectedAreaIndex}
+        onDeleteArea={handleDeleteArea}
+        onUpdateArea={handleUpdateArea}
+      />
     </div>
   );
 }

--- a/src/constants/richmenu.ts
+++ b/src/constants/richmenu.ts
@@ -1,0 +1,26 @@
+import type { RichMenuSize, RichMenuSizeType } from "@/types/richmenu";
+
+export const RICHMENU_SIZES: Record<RichMenuSizeType, RichMenuSize> = {
+  full: { width: 2500, height: 1686 },
+  half: { width: 2500, height: 843 },
+};
+
+export const AREA_COLORS = [
+  "rgba(59, 130, 246, 0.3)", // blue
+  "rgba(239, 68, 68, 0.3)", // red
+  "rgba(34, 197, 94, 0.3)", // green
+  "rgba(234, 179, 8, 0.3)", // yellow
+  "rgba(168, 85, 247, 0.3)", // purple
+  "rgba(236, 72, 153, 0.3)", // pink
+];
+
+export const MIN_AREA_SIZE = 10;
+export const LABEL_FONT_SIZE = 14;
+export const LABEL_OFFSET_X = 5;
+export const LABEL_OFFSET_Y = 20;
+export const SELECTED_BORDER_WIDTH = 3;
+export const DEFAULT_BORDER_WIDTH = 2;
+export const SELECTED_BORDER_COLOR = "#3b82f6";
+export const DEFAULT_BORDER_COLOR = "#ffffff";
+export const LABEL_COLOR = "#ffffff";
+export const DRAWING_PREVIEW_COLOR = "rgba(59, 130, 246, 0.3)";

--- a/src/hooks/useAreaSelection.ts
+++ b/src/hooks/useAreaSelection.ts
@@ -1,0 +1,125 @@
+import { useState, useCallback, RefObject } from "react";
+import type { TapArea, Point } from "@/types/richmenu";
+import { getCanvasCoordinates, isPointInArea, calculateRectangle } from "@/utils/canvasCoordinates";
+import { MIN_AREA_SIZE } from "@/constants/richmenu";
+
+interface UseAreaSelectionProps {
+  canvasRef: RefObject<HTMLCanvasElement | null>;
+  areas: TapArea[];
+  onAreasChange: (areas: TapArea[]) => void;
+  scale: number;
+}
+
+export function useAreaSelection({
+  canvasRef,
+  areas,
+  onAreasChange,
+  scale,
+}: UseAreaSelectionProps) {
+  const [selectedAreaIndex, setSelectedAreaIndex] = useState<number | null>(null);
+  const [isDrawing, setIsDrawing] = useState(false);
+  const [drawStart, setDrawStart] = useState<Point | null>(null);
+  const [currentDraw, setCurrentDraw] = useState<Point | null>(null);
+
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent<HTMLCanvasElement>) => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+
+      const coords = getCanvasCoordinates(e, canvas);
+
+      // Check if clicking on existing area
+      const clickedIndex = areas.findIndex((area) => isPointInArea(coords, area, scale));
+
+      if (clickedIndex !== -1) {
+        setSelectedAreaIndex(clickedIndex);
+        return;
+      }
+
+      // Start drawing new area
+      setSelectedAreaIndex(null);
+      setIsDrawing(true);
+      setDrawStart(coords);
+      setCurrentDraw(coords);
+    },
+    [canvasRef, areas, scale]
+  );
+
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent<HTMLCanvasElement>) => {
+      if (!isDrawing || !canvasRef.current) return;
+      setCurrentDraw(getCanvasCoordinates(e, canvasRef.current));
+    },
+    [isDrawing, canvasRef]
+  );
+
+  const handleMouseUp = useCallback(
+    (e: React.MouseEvent<HTMLCanvasElement>) => {
+      if (!isDrawing || !drawStart || !canvasRef.current) return;
+
+      const coords = getCanvasCoordinates(e, canvasRef.current);
+      const bounds = calculateRectangle(drawStart, coords, scale);
+
+      // Only add area if it has meaningful size
+      if (bounds.width > MIN_AREA_SIZE && bounds.height > MIN_AREA_SIZE) {
+        const newArea: TapArea = {
+          bounds,
+          action: {
+            type: "uri",
+            uri: "https://example.com",
+          },
+        };
+        onAreasChange([...areas, newArea]);
+        setSelectedAreaIndex(areas.length);
+      }
+
+      setIsDrawing(false);
+      setDrawStart(null);
+      setCurrentDraw(null);
+    },
+    [isDrawing, drawStart, canvasRef, scale, areas, onAreasChange]
+  );
+
+  const handleMouseLeave = useCallback(() => {
+    if (isDrawing) {
+      setIsDrawing(false);
+      setDrawStart(null);
+      setCurrentDraw(null);
+    }
+  }, [isDrawing]);
+
+  const handleDeleteArea = useCallback(
+    (index: number) => {
+      onAreasChange(areas.filter((_, i) => i !== index));
+      if (selectedAreaIndex === index) {
+        setSelectedAreaIndex(null);
+      } else if (selectedAreaIndex !== null && selectedAreaIndex > index) {
+        setSelectedAreaIndex(selectedAreaIndex - 1);
+      }
+    },
+    [areas, selectedAreaIndex, onAreasChange]
+  );
+
+  const handleUpdateArea = useCallback(
+    (index: number, updates: Partial<TapArea>) => {
+      const newAreas = [...areas];
+      newAreas[index] = { ...newAreas[index], ...updates };
+      onAreasChange(newAreas);
+    },
+    [areas, onAreasChange]
+  );
+
+  return {
+    selectedAreaIndex,
+    setSelectedAreaIndex,
+    isDrawing,
+    drawStart,
+    currentDraw,
+    handleMouseDown,
+    handleMouseMove,
+    handleMouseUp,
+    handleMouseLeave,
+    handleDeleteArea,
+    handleUpdateArea,
+  };
+}

--- a/src/hooks/useCanvasDrawing.ts
+++ b/src/hooks/useCanvasDrawing.ts
@@ -1,0 +1,64 @@
+import { useEffect, RefObject } from "react";
+import type { TapArea, RichMenuSize, Point } from "@/types/richmenu";
+import { drawImage, drawArea, drawAreaLabel, drawDrawingPreview } from "@/utils/canvasDrawing";
+
+interface UseCanvasDrawingProps {
+  canvasRef: RefObject<HTMLCanvasElement | null>;
+  image: HTMLImageElement | null;
+  richMenuSize: RichMenuSize;
+  scale: number;
+  areas: TapArea[];
+  selectedAreaIndex: number | null;
+  isDrawing: boolean;
+  drawStart: Point | null;
+  currentDraw: Point | null;
+}
+
+export function useCanvasDrawing({
+  canvasRef,
+  image,
+  richMenuSize,
+  scale,
+  areas,
+  selectedAreaIndex,
+  isDrawing,
+  drawStart,
+  currentDraw,
+}: UseCanvasDrawingProps) {
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || !image) return;
+
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    // Set canvas size
+    canvas.width = richMenuSize.width * scale;
+    canvas.height = richMenuSize.height * scale;
+
+    // Draw image
+    drawImage(ctx, image, canvas.width, canvas.height);
+
+    // Draw existing areas
+    areas.forEach((area, index) => {
+      const isSelected = index === selectedAreaIndex;
+      drawArea(ctx, area, scale, index, isSelected);
+      drawAreaLabel(ctx, area, index, scale);
+    });
+
+    // Draw current drawing area
+    if (isDrawing && drawStart && currentDraw) {
+      drawDrawingPreview(ctx, drawStart, currentDraw);
+    }
+  }, [
+    canvasRef,
+    image,
+    areas,
+    selectedAreaIndex,
+    isDrawing,
+    drawStart,
+    currentDraw,
+    scale,
+    richMenuSize,
+  ]);
+}

--- a/src/hooks/useCanvasScale.ts
+++ b/src/hooks/useCanvasScale.ts
@@ -1,0 +1,28 @@
+import { useState, useEffect, RefObject } from "react";
+import type { RichMenuSize } from "@/types/richmenu";
+
+export function useCanvasScale(
+  containerRef: RefObject<HTMLDivElement | null>,
+  richMenuSize: RichMenuSize
+) {
+  const [scale, setScale] = useState(1);
+
+  const updateScale = () => {
+    if (!containerRef.current) return;
+    const containerWidth = containerRef.current.clientWidth;
+    const newScale = Math.min(containerWidth / richMenuSize.width, 1);
+    setScale(newScale);
+  };
+
+  useEffect(() => {
+    updateScale();
+  }, [richMenuSize]);
+
+  useEffect(() => {
+    const handleResize = () => updateScale();
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, [richMenuSize]);
+
+  return scale;
+}

--- a/src/types/richmenu.ts
+++ b/src/types/richmenu.ts
@@ -1,0 +1,27 @@
+export interface TapArea {
+  bounds: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  };
+  action: {
+    type: "uri" | "message" | "postback";
+    label?: string;
+    uri?: string;
+    text?: string;
+    data?: string;
+  };
+}
+
+export interface RichMenuSize {
+  width: number;
+  height: number;
+}
+
+export type RichMenuSizeType = "full" | "half";
+
+export interface Point {
+  x: number;
+  y: number;
+}

--- a/src/utils/canvasCoordinates.ts
+++ b/src/utils/canvasCoordinates.ts
@@ -1,0 +1,43 @@
+import type { Point, TapArea } from "@/types/richmenu";
+
+export function getCanvasCoordinates(
+  e: React.MouseEvent<HTMLCanvasElement>,
+  canvas: HTMLCanvasElement
+): Point {
+  const rect = canvas.getBoundingClientRect();
+  return {
+    x: e.clientX - rect.left,
+    y: e.clientY - rect.top,
+  };
+}
+
+export function isPointInArea(point: Point, area: TapArea, scale: number): boolean {
+  const x = area.bounds.x * scale;
+  const y = area.bounds.y * scale;
+  const w = area.bounds.width * scale;
+  const h = area.bounds.height * scale;
+  return point.x >= x && point.x <= x + w && point.y >= y && point.y <= y + h;
+}
+
+export function calculateRectangle(start: Point, end: Point, scale: number) {
+  const x = Math.min(start.x, end.x) / scale;
+  const y = Math.min(start.y, end.y) / scale;
+  const width = Math.abs(end.x - start.x) / scale;
+  const height = Math.abs(end.y - start.y) / scale;
+
+  return {
+    x: Math.round(x),
+    y: Math.round(y),
+    width: Math.round(width),
+    height: Math.round(height),
+  };
+}
+
+export function normalizeRectangle(start: Point, end: Point) {
+  return {
+    x: Math.min(start.x, end.x),
+    y: Math.min(start.y, end.y),
+    width: Math.abs(end.x - start.x),
+    height: Math.abs(end.y - start.y),
+  };
+}

--- a/src/utils/canvasDrawing.ts
+++ b/src/utils/canvasDrawing.ts
@@ -1,0 +1,74 @@
+import type { TapArea, Point } from "@/types/richmenu";
+import {
+  AREA_COLORS,
+  SELECTED_BORDER_WIDTH,
+  DEFAULT_BORDER_WIDTH,
+  SELECTED_BORDER_COLOR,
+  DEFAULT_BORDER_COLOR,
+  LABEL_COLOR,
+  LABEL_FONT_SIZE,
+  LABEL_OFFSET_X,
+  LABEL_OFFSET_Y,
+  DRAWING_PREVIEW_COLOR,
+} from "@/constants/richmenu";
+import { normalizeRectangle } from "./canvasCoordinates";
+
+export function drawImage(
+  ctx: CanvasRenderingContext2D,
+  image: HTMLImageElement,
+  width: number,
+  height: number
+) {
+  ctx.drawImage(image, 0, 0, width, height);
+}
+
+export function drawArea(
+  ctx: CanvasRenderingContext2D,
+  area: TapArea,
+  scale: number,
+  colorIndex: number,
+  isSelected: boolean
+) {
+  const x = area.bounds.x * scale;
+  const y = area.bounds.y * scale;
+  const width = area.bounds.width * scale;
+  const height = area.bounds.height * scale;
+
+  // Fill area with color
+  ctx.fillStyle = AREA_COLORS[colorIndex % AREA_COLORS.length];
+  ctx.fillRect(x, y, width, height);
+
+  // Draw border
+  ctx.strokeStyle = isSelected ? SELECTED_BORDER_COLOR : DEFAULT_BORDER_COLOR;
+  ctx.lineWidth = isSelected ? SELECTED_BORDER_WIDTH : DEFAULT_BORDER_WIDTH;
+  ctx.strokeRect(x, y, width, height);
+}
+
+export function drawAreaLabel(
+  ctx: CanvasRenderingContext2D,
+  area: TapArea,
+  index: number,
+  scale: number
+) {
+  ctx.fillStyle = LABEL_COLOR;
+  ctx.font = `bold ${LABEL_FONT_SIZE * scale}px sans-serif`;
+  ctx.fillText(
+    `Area ${index + 1}`,
+    area.bounds.x * scale + LABEL_OFFSET_X,
+    area.bounds.y * scale + LABEL_OFFSET_Y * scale
+  );
+}
+
+export function drawDrawingPreview(
+  ctx: CanvasRenderingContext2D,
+  drawStart: Point,
+  currentDraw: Point
+) {
+  const rect = normalizeRectangle(drawStart, currentDraw);
+
+  ctx.fillStyle = DRAWING_PREVIEW_COLOR;
+  ctx.fillRect(rect.x, rect.y, rect.width, rect.height);
+  ctx.strokeStyle = SELECTED_BORDER_COLOR;
+  ctx.lineWidth = DEFAULT_BORDER_WIDTH;
+  ctx.strokeRect(rect.x, rect.y, rect.width, rect.height);
+}


### PR DESCRIPTION
- Extract types to src/types/richmenu.ts (TapArea, RichMenuSize, Point)
- Extract constants to src/constants/richmenu.ts (RICHMENU_SIZES, AREA_COLORS, etc.)
- Create utility functions:
  - src/utils/canvasCoordinates.ts: coordinate transformation and hit detection
  - src/utils/canvasDrawing.ts: pure drawing functions for canvas
- Create custom hooks:
  - useCanvasScale: responsive canvas scaling logic
  - useCanvasDrawing: canvas rendering logic
  - useAreaSelection: area selection and drawing interaction logic
- Create smaller components:
  - AreaActionForm: action type selection and configuration
  - AreaItem: individual area display and controls
  - AreaList: area list with empty state
  - RichMenuCanvas: canvas rendering and event handling
- Refactor VisualEditor: reduce from 390 lines to ~100 lines
- All existing tests pass without modification
- No breaking changes to the public API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visual editor for creating and editing interactive tap areas on rich menu images
  * Support for multiple action types (URI, message, postback) with dedicated field editors
  * Interactive canvas enabling click-and-drag drawing to define new areas, with selection and deletion capabilities
  * Area management interface displaying all configured areas with visual labels and editing controls

<!-- end of auto-generated comment: release notes by coderabbit.ai -->